### PR TITLE
Breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/opal-frontend-common-node",
   "type": "module",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Common nodejs library components for opal",
   "main": "dist/index",
   "types": "dist/index.d.ts",

--- a/src/interfaces/session-storage-config.ts
+++ b/src/interfaces/session-storage-config.ts
@@ -6,7 +6,7 @@ class SessionStorageConfiguration {
   secure!: boolean;
   domain!: string;
   redisEnabled!: boolean;
-  redisConnectionString!: string | null;
+  redisConnectionString!: string;
 }
 
 export default SessionStorageConfiguration;

--- a/src/session/session-storage/index.ts
+++ b/src/session/session-storage/index.ts
@@ -34,8 +34,8 @@ export default class SessionStorage {
     );
   }
 
-  private getStore(app: Application, enabled: boolean, connectionString: string | null) {
-    if (enabled && connectionString) {
+  private getStore(app: Application, enabled: boolean, connectionString: string) {
+    if (enabled) {
       logger.info('Using Redis session store', connectionString);
       const client = createClient({
         url: connectionString,


### PR DESCRIPTION
### Jira link

### Change description
- **Breaking change**: Redis may incorrectly fall back to using localhost:6379 when the connection string is null or undefined. This issue originated from the redisConnectionString property in the SessionStorageConfiguration class being typed as string | null, which allowed the Redis client to initialise without a valid connection string. In such cases, the Redis client defaults silently to localhost, leading to unexpected behaviour in environments like AKS.
- **To resolve this**, the type has been changed to a non-nullable string, aligning with the expected behaviour of config.get('secrets.opal.redis-connection-string'), which throws an error if the key is not defined. This change ensures that the application fails fast during startup if the connection string is missing or misconfigured, rather than silently falling through to localhost. It also makes the configuration more robust and predictable across environments.

### Work undertaken
- Previously, in the old `session-storeage.ts` we had the following: 
```typescript
if (config.get('features.redis.enabled')) {
      logger.info('Using Redis session store', config.get('secrets.opal.redis-connection-string'));
      const client = createClient({
```
- Currently, we have this in the `index.ts`: 
```typescript
if (enabled && connectionString) {
      logger.info('Using Redis session store', connectionString);
      const client = createClient({
```
- I have amended this to: 
```typescript
if (enabled) {
      logger.info('Using Redis session store', connectionString);
      const client = createClient({
```
- Redis connection string is still being set in [here](https://github.com/hmcts/opal-frontend/blob/b78578fcac0064a87c67fec166f8138970286d17/server-setup.ts#L19) in the `server-config.ts`:
```typescript
const sessionStorageConfig: SessionStorageConfiguration = {
  secret: config.get('secrets.opal.opal-frontend-cookie-secret'),
  prefix: config.get('session.prefix'),
  maxAge: config.get('session.maxAge'),
  sameSite: config.get('session.sameSite'),
  secure: config.get('session.secure'),
  domain: config.get('session.domain'),
  redisEnabled: config.get('features.redis.enabled'),
  redisConnectionString: config.get('secrets.opal.redis-connection-string'),
};
```

### Testing done
- Works locally with Redis enabled (but that would work regardless)

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
