### PR TITLE
feat: implement Redis-backed user-state caching for SSO checks and update version to 0.0.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,7 @@ The format is based on Keep a Changelog and this project follows semantic versio
   client.
 - Remove the obsolete generic `opalApiUrl` proxy configuration from `ProxyConfiguration` and default proxy
   config.
-- Use the configured Redis-backed user-state route cache during SSO user checks to avoid refreshing Redis on repeat
-  sign-ins when cached state already exists.
+- Clear the logged-in user's Redis-backed user-state cache entry during SSO logout.
 
 ## Changelog Policy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on Keep a Changelog and this project follows semantic versio
   client.
 - Remove the obsolete generic `opalApiUrl` proxy configuration from `ProxyConfiguration` and default proxy
   config.
+- Use the configured Redis-backed user-state route cache during SSO user checks to avoid refreshing Redis on repeat
+  sign-ins when cached state already exists.
 
 ## Changelog Policy
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/opal-frontend-common-node",
   "type": "module",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "license": "MIT",
   "description": "Common nodejs library components for opal",
   "engines": {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -42,6 +42,7 @@ export class Routes {
     ssoConfiguration: SsoConfiguration,
     routesConfiguration: RoutesConfiguration,
     opalUserServiceConfig: OpalUserServiceConfig,
+    userStateConfiguration: UserStateConfiguration,
     opalUserServiceUrl: string,
   ): void {
     if (!routesConfiguration.clientId || !routesConfiguration.clientSecret || !routesConfiguration.tenantId) {
@@ -72,6 +73,7 @@ export class Routes {
         clientId: routesConfiguration.clientId,
         opalUserServiceConfig,
         opalUserServiceUrl,
+        userStateConfiguration,
       }),
     );
 
@@ -157,7 +159,14 @@ export class Routes {
     const opalUserServiceUrl = this.requireConfiguredUrl(proxyConfiguration.opalUserServiceUrl, 'opalUserServiceUrl');
 
     if (ssoEnabled) {
-      this.setupSSORoutes(app, ssoConfiguration, routesConfiguration, opalUserServiceConfig, opalUserServiceUrl);
+      this.setupSSORoutes(
+        app,
+        ssoConfiguration,
+        routesConfiguration,
+        opalUserServiceConfig,
+        userStateConfiguration,
+        opalUserServiceUrl,
+      );
     } else {
       this.setupStubRoutes(app, ssoConfiguration, routesConfiguration, opalUserServiceUrl);
     }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -88,7 +88,7 @@ export class Routes {
 
     // LOGOUT CALLBACK
     app.get(ssoConfiguration.logoutCallback, (req: Request, res: Response, next: NextFunction) =>
-      ssoLogoutCallback(req, res, next, routesConfiguration.prefix),
+      ssoLogoutCallback(req, res, next, routesConfiguration.prefix, { userStateConfiguration }),
     );
 
     // AUTHENTICATED

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,5 @@
 export { getUserStateFromUserService, handleCheckUser } from './opal-user-service.js';
-export type { UserStateLookupResult } from './opal-user-service.js';
+export type { HandleCheckUserOptions, UserStateLookupResult } from './opal-user-service.js';
 export {
   default as RedisService,
   RedisCacheParseError,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -2,6 +2,7 @@ export { getUserStateFromUserService, handleCheckUser } from './opal-user-servic
 export type { HandleCheckUserOptions, UserStateLookupResult } from './opal-user-service.js';
 export {
   default as RedisService,
+  RedisCacheDeleteError,
   RedisCacheParseError,
   RedisCacheReadError,
   RedisClientUnavailableError,

--- a/src/services/opal-user-service.ts
+++ b/src/services/opal-user-service.ts
@@ -1,12 +1,59 @@
 import axios from 'axios';
+import type { Application } from 'express';
 import { Logger } from '@hmcts/nodejs-logging';
 import OpalUserServiceConfiguration from '../interfaces/opal-user-service-config.js';
+import type UserStateConfiguration from '../interfaces/user-state-config.js';
+import { getCachedUserStateForAccessToken } from '../user-state/user-state-cache.js';
+import type RedisService from './redis-service.js';
 
 const logger = Logger.getLogger('opal-user-service');
 
 export interface UserStateLookupResult {
   data: unknown;
   status: number;
+}
+
+interface UserCheckResult {
+  status: number;
+  user_id?: string;
+  version?: string;
+}
+
+export interface HandleCheckUserOptions {
+  app: Application;
+  redisService?: RedisService;
+  userStateConfiguration: UserStateConfiguration;
+}
+
+async function getCachedUserCheckResult(
+  accessToken: string,
+  options?: HandleCheckUserOptions,
+): Promise<UserCheckResult | null> {
+  if (!options) {
+    return null;
+  }
+
+  const cachedUserState = await getCachedUserStateForAccessToken({
+    accessToken,
+    app: options.app,
+    redisService: options.redisService,
+    userStateConfiguration: options.userStateConfiguration,
+  });
+
+  switch (cachedUserState.status) {
+    case 'hit':
+      return { status: 200 };
+
+    case 'invalid-token':
+      return { status: 401 };
+
+    case 'cache-error':
+      logger.error('Unable to read cached user state when checking user', cachedUserState.error);
+      return { status: 503 };
+
+    case 'miss':
+      return null;
+  }
 }
 
 /**
@@ -19,7 +66,14 @@ async function checkUserExists(
   opalUserServiceTarget: string,
   accessToken: string,
   userStateUrl: string,
-): Promise<{ status: number; user_id?: string; version?: string }> {
+  options?: HandleCheckUserOptions,
+): Promise<UserCheckResult> {
+  const cachedUserResult = await getCachedUserCheckResult(accessToken, options);
+
+  if (cachedUserResult) {
+    return cachedUserResult;
+  }
+
   try {
     const response = await axios.get(`${opalUserServiceTarget}${userStateUrl}`, {
       headers: {
@@ -174,8 +228,9 @@ export async function handleCheckUser(
   opalUserServiceTarget: string,
   accessToken: string,
   config: OpalUserServiceConfiguration,
+  options?: HandleCheckUserOptions,
 ): Promise<boolean> {
-  const userResult = await checkUserExists(opalUserServiceTarget, accessToken, config.userStateUrl);
+  const userResult = await checkUserExists(opalUserServiceTarget, accessToken, config.userStateUrl, options);
 
   switch (userResult.status) {
     case 200:

--- a/src/services/opal-user-service.ts
+++ b/src/services/opal-user-service.ts
@@ -30,6 +30,7 @@ async function getCachedUserCheckResult(
   options?: HandleCheckUserOptions,
 ): Promise<UserCheckResult | null> {
   if (!options) {
+    logger.info('User-state cache lookup skipped during user check: cache configuration not provided');
     return null;
   }
 
@@ -42,9 +43,11 @@ async function getCachedUserCheckResult(
 
   switch (cachedUserState.status) {
     case 'hit':
+      logger.info('User-state cache hit during user check');
       return { status: 200 };
 
     case 'invalid-token':
+      logger.warn('Unable to derive user-state cache key during user check');
       return { status: 401 };
 
     case 'cache-error':
@@ -52,6 +55,7 @@ async function getCachedUserCheckResult(
       return { status: 503 };
 
     case 'miss':
+      logger.info('User-state cache miss during user check, checking opal-user-service');
       return null;
   }
 }
@@ -75,6 +79,7 @@ async function checkUserExists(
   }
 
   try {
+    logger.info('Checking user state with opal-user-service');
     const response = await axios.get(`${opalUserServiceTarget}${userStateUrl}`, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -92,6 +97,7 @@ async function checkUserExists(
     if (axios.isAxiosError(error)) {
       const status = error.response?.status;
       if (status) {
+        logger.info('opal-user-service user state check returned non-success response', { status });
         return {
           status,
           // For 409 conflicts, extract user_id from resourceId

--- a/src/services/redis-service.ts
+++ b/src/services/redis-service.ts
@@ -5,6 +5,7 @@ import { decodeObject } from '../utils/base64.js';
 
 export interface RedisClient {
   get(key: string): Promise<string | null>;
+  del?: (key: string) => Promise<number>;
 }
 
 interface JwtPayload {
@@ -27,6 +28,13 @@ export class RedisCacheReadError extends Error {
   }
 }
 
+export class RedisCacheDeleteError extends Error {
+  public constructor(options?: { cause?: unknown }) {
+    super('Unable to delete from Redis cache', options);
+    this.name = 'RedisCacheDeleteError';
+  }
+}
+
 export class RedisCacheParseError extends Error {
   public constructor() {
     super('Redis cache payload is not a JSON object');
@@ -34,7 +42,11 @@ export class RedisCacheParseError extends Error {
   }
 }
 
-export type RedisCacheError = RedisClientUnavailableError | RedisCacheReadError | RedisCacheParseError;
+export type RedisCacheError =
+  | RedisClientUnavailableError
+  | RedisCacheReadError
+  | RedisCacheDeleteError
+  | RedisCacheParseError;
 
 export default class RedisService {
   /**
@@ -145,6 +157,28 @@ export default class RedisService {
     }
 
     return cachedJsonObject;
+  }
+
+  /**
+   * Deletes a cache entry from Redis.
+   *
+   * @param app - Express application that may hold the Redis client on `locals`.
+   * @param cacheKey - Redis key for the cached payload.
+   * @returns true when an entry was deleted, false when the key was not present.
+   * @throws RedisCacheError when Redis cannot be written to.
+   */
+  public async deleteCachedJsonObject(app: Application, cacheKey: string): Promise<boolean> {
+    const redisClient = this.getRedisClient(app);
+
+    if (!redisClient || typeof redisClient.del !== 'function') {
+      throw new RedisClientUnavailableError();
+    }
+
+    try {
+      return (await redisClient.del(cacheKey)) > 0;
+    } catch (error: unknown) {
+      throw new RedisCacheDeleteError({ cause: error });
+    }
   }
 
   /**

--- a/src/sso/sso-login-callback.ts
+++ b/src/sso/sso-login-callback.ts
@@ -49,6 +49,8 @@ export default async function ssoLoginCallbackHandler({
     redirectUri: `${frontendHostname}${ssoLoginCallback}`,
   };
 
+  logger.info('SSO login callback received');
+
   if (!tokenRequest.code) {
     logger.warn('Missing authorization code on SSO callback');
     res.status(400).send('Missing authorization code');
@@ -84,6 +86,7 @@ export default async function ssoLoginCallbackHandler({
     if (!response?.accessToken) throw new Error('No access token in token response');
 
     const accessToken = response.accessToken;
+    logger.info('SSO access token acquired, checking user management state');
     // Validate and manage user in opal-user-service
     const userManagementSuccess = await handleCheckUser(
       opalUserServiceUrl,
@@ -97,13 +100,18 @@ export default async function ssoLoginCallbackHandler({
       return;
     }
 
+    logger.info('SSO user management completed successfully');
+
     const securityToken: SecurityToken = {
       user_state: undefined,
       access_token: accessToken,
     };
 
     req.session.securityToken = securityToken;
-    req.session.save(() => res.redirect(frontendHostname));
+    req.session.save(() => {
+      logger.info('SSO login callback completed, redirecting to frontend');
+      res.redirect(frontendHostname);
+    });
     return;
   } catch (error) {
     logger.error('Error on SSO Login Callback', {

--- a/src/sso/sso-login-callback.ts
+++ b/src/sso/sso-login-callback.ts
@@ -5,6 +5,7 @@ import { SecurityToken } from '../interfaces/index.js';
 import { Logger } from '@hmcts/nodejs-logging';
 import { handleCheckUser } from '../services/opal-user-service.js';
 import OpalUserServiceConfiguration from '../interfaces/opal-user-service-config.js';
+import type UserStateConfiguration from '../interfaces/user-state-config.js';
 
 const logger = Logger.getLogger('sso-login-callback');
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -18,6 +19,7 @@ export interface SsoLoginCallbackHandlerOptions {
   clientId: string;
   opalUserServiceConfig: OpalUserServiceConfiguration;
   opalUserServiceUrl: string;
+  userStateConfiguration?: UserStateConfiguration;
 }
 
 /**
@@ -38,6 +40,7 @@ export default async function ssoLoginCallbackHandler({
   clientId,
   opalUserServiceConfig,
   opalUserServiceUrl,
+  userStateConfiguration,
 }: SsoLoginCallbackHandlerOptions): Promise<void> {
   // Build the token request for MSAL using the auth code returned by the IdP.
   const tokenRequest = {
@@ -82,7 +85,12 @@ export default async function ssoLoginCallbackHandler({
 
     const accessToken = response.accessToken;
     // Validate and manage user in opal-user-service
-    const userManagementSuccess = await handleCheckUser(opalUserServiceUrl, accessToken, opalUserServiceConfig);
+    const userManagementSuccess = await handleCheckUser(
+      opalUserServiceUrl,
+      accessToken,
+      opalUserServiceConfig,
+      userStateConfiguration ? { app: req.app, userStateConfiguration } : undefined,
+    );
     if (!userManagementSuccess) {
       logger.error('User management failed after successful token acquisition');
       res.status(500).send('User validation failed');

--- a/src/sso/sso-logout-callback.ts
+++ b/src/sso/sso-logout-callback.ts
@@ -1,7 +1,49 @@
 import { NextFunction, Request, Response } from 'express';
 import { Logger } from '@hmcts/nodejs-logging';
+import type UserStateConfiguration from '../interfaces/user-state-config.js';
+import RedisService from '../services/redis-service.js';
 
-const logger = Logger.getLogger('logout');
+const logger = Logger.getLogger('sso-logout-callback');
+
+export interface SsoLogoutCallbackOptions {
+  redisService?: RedisService;
+  userStateConfiguration?: UserStateConfiguration;
+}
+
+async function clearUserStateCache(req: Request, options: SsoLogoutCallbackOptions): Promise<void> {
+  const { userStateConfiguration } = options;
+  const accessToken = req.session.securityToken?.access_token;
+
+  if (!userStateConfiguration) {
+    logger.info('User state cache cleanup skipped during logout: cache configuration not provided');
+    return;
+  }
+
+  if (!accessToken) {
+    logger.info('User state cache cleanup skipped during logout: access token not available');
+    return;
+  }
+
+  const redisService = options.redisService ?? new RedisService();
+  const cacheKey = redisService.getCacheKey(
+    accessToken,
+    userStateConfiguration.tokenClaim,
+    userStateConfiguration.cacheKeyPrefix,
+  );
+
+  if (!cacheKey) {
+    logger.warn('Unable to derive user state cache key during logout');
+    return;
+  }
+
+  const deleted = await redisService.deleteCachedJsonObject(req.app, cacheKey);
+
+  if (deleted) {
+    logger.info('Cleared user state cache on logout');
+  } else {
+    logger.info('User state cache entry not found during logout');
+  }
+}
 
 /**
  * Express middleware to handle SSO logout callback.
@@ -12,8 +54,23 @@ const logger = Logger.getLogger('logout');
  * @param res - Express response object.
  * @param next - Express next middleware function.
  * @param prefix - The name of the cookie to clear.
+ * @param options - Optional Redis user-state cache cleanup dependencies.
  */
-export default function handleLogoutCallback(req: Request, res: Response, next: NextFunction, prefix: string) {
+export default async function handleLogoutCallback(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  prefix: string,
+  options: SsoLogoutCallbackOptions = {},
+) {
+  logger.info('SSO logout callback received');
+
+  try {
+    await clearUserStateCache(req, options);
+  } catch (error) {
+    logger.error('Unable to clear user state cache during logout', error);
+  }
+
   req.session.destroy((err) => {
     if (err) {
       logger.error('Error destroying session', err);
@@ -22,6 +79,7 @@ export default function handleLogoutCallback(req: Request, res: Response, next: 
 
     res.clearCookie(prefix);
 
+    logger.info('SSO logout callback completed, redirecting to home');
     res.redirect('/');
   });
 }

--- a/src/user-state/index.ts
+++ b/src/user-state/index.ts
@@ -1,16 +1,13 @@
 import type { Application, Request, Response } from 'express';
+import { Logger } from '@hmcts/nodejs-logging';
 import type OpalUserServiceConfiguration from '../interfaces/opal-user-service-config.js';
 import type UserStateConfiguration from '../interfaces/user-state-config.js';
 import { getUserStateFromUserService } from '../services/opal-user-service.js';
-import RedisService, {
-  RedisCacheParseError,
-  RedisCacheReadError,
-  RedisClientUnavailableError,
-  type CachedJsonObject,
-} from '../services/redis-service.js';
+import RedisService from '../services/redis-service.js';
 import { Jwt } from '../utils/index.js';
+import { getCachedUserStateForAccessToken, USER_STATE_CACHE_FAILURE_MESSAGE } from './user-state-cache.js';
 
-const USER_STATE_CACHE_FAILURE_MESSAGE = 'Unable to retrieve user state from cache';
+const logger = Logger.getLogger('user-state');
 
 export interface UserStateHandlerOptions {
   app: Application;
@@ -39,42 +36,8 @@ function isSuccessfulResponse(status: number): boolean {
   return status >= 200 && status < 300;
 }
 
-function isRedisCacheError(error: unknown): boolean {
-  return (
-    error instanceof RedisClientUnavailableError ||
-    error instanceof RedisCacheReadError ||
-    error instanceof RedisCacheParseError
-  );
-}
-
 function sendCacheFailureResponse(res: Response): void {
   res.status(503).send({ message: USER_STATE_CACHE_FAILURE_MESSAGE });
-}
-
-function getMatchingUserState(cachedUserState: CachedJsonObject | null, cacheKey: string): CachedJsonObject | null {
-  if (!cachedUserState) {
-    return null;
-  }
-
-  return cachedUserState['cache_name'] === cacheKey ? cachedUserState : null;
-}
-
-async function getCachedUserState(
-  app: Application,
-  cacheKey: string,
-  redisService: RedisService,
-  res: Response,
-): Promise<CachedJsonObject | null | undefined> {
-  try {
-    return await redisService.getCachedJsonObject(app, cacheKey);
-  } catch (error: unknown) {
-    if (!isRedisCacheError(error)) {
-      throw error;
-    }
-
-    sendCacheFailureResponse(res);
-    return undefined;
-  }
 }
 
 /**
@@ -100,32 +63,37 @@ export async function getUserState({
   const accessToken = getAccessToken(req);
 
   if (!accessToken || Jwt.isJwtExpired(accessToken)) {
+    logger.warn('Unable to retrieve user state: missing or expired access token');
     res.sendStatus(401);
     return;
   }
 
-  const cacheKey = redisService.getCacheKey(
+  const cachedUserState = await getCachedUserStateForAccessToken({
     accessToken,
-    userStateConfiguration.tokenClaim,
-    userStateConfiguration.cacheKeyPrefix,
-  );
+    app,
+    redisService,
+    userStateConfiguration,
+  });
 
-  if (!cacheKey) {
-    res.sendStatus(401);
-    return;
-  }
+  switch (cachedUserState.status) {
+    case 'hit':
+      logger.info('User state cache hit');
+      res.status(200).json(cachedUserState.userState);
+      return;
 
-  const cachedUserState = await getCachedUserState(app, cacheKey, redisService, res);
+    case 'invalid-token':
+      logger.warn('Unable to derive user state cache key from access token');
+      res.sendStatus(401);
+      return;
 
-  if (cachedUserState === undefined) {
-    return;
-  }
+    case 'cache-error':
+      logger.error('Unable to retrieve user state from cache', cachedUserState.error);
+      sendCacheFailureResponse(res);
+      return;
 
-  const matchingCachedUserState = getMatchingUserState(cachedUserState, cacheKey);
-
-  if (matchingCachedUserState) {
-    res.status(200).json(matchingCachedUserState);
-    return;
+    case 'miss':
+      logger.info('User state cache miss, retrieving from opal-user-service');
+      break;
   }
 
   const userStateResponse = await getUserStateFromUserService(
@@ -135,22 +103,37 @@ export async function getUserState({
   );
 
   if (isSuccessfulResponse(userStateResponse.status)) {
-    const repopulatedUserState = await getCachedUserState(app, cacheKey, redisService, res);
+    logger.info('opal-user-service returned user state successfully, reading repopulated cache');
+    const repopulatedUserState = await getCachedUserStateForAccessToken({
+      accessToken,
+      app,
+      redisService,
+      userStateConfiguration,
+    });
 
-    if (repopulatedUserState === undefined) {
-      return;
+    switch (repopulatedUserState.status) {
+      case 'hit':
+        logger.info('Repopulated user state cache hit');
+        res.status(200).json(repopulatedUserState.userState);
+        return;
+
+      case 'invalid-token':
+        logger.warn('Unable to derive user state cache key from access token after opal-user-service response');
+        res.sendStatus(401);
+        return;
+
+      case 'cache-error':
+        logger.error('Unable to retrieve repopulated user state from cache', repopulatedUserState.error);
+        sendCacheFailureResponse(res);
+        return;
+
+      case 'miss':
+        logger.error('opal-user-service returned success but user state was not available in cache');
+        res.status(502).send({ message: USER_STATE_CACHE_FAILURE_MESSAGE });
+        return;
     }
-
-    const matchingRepopulatedUserState = getMatchingUserState(repopulatedUserState, cacheKey);
-
-    if (matchingRepopulatedUserState) {
-      res.status(200).json(matchingRepopulatedUserState);
-      return;
-    }
-
-    res.status(502).send({ message: USER_STATE_CACHE_FAILURE_MESSAGE });
-    return;
   }
 
+  logger.warn('opal-user-service returned non-success response for user state', { status: userStateResponse.status });
   sendDownstreamResponse(res, userStateResponse.status, userStateResponse.data);
 }

--- a/src/user-state/index.ts
+++ b/src/user-state/index.ts
@@ -103,7 +103,9 @@ export async function getUserState({
   );
 
   if (isSuccessfulResponse(userStateResponse.status)) {
-    logger.info('opal-user-service returned user state successfully, reading repopulated cache');
+    logger.info('opal-user-service returned successful response for user state, reading repopulated cache', {
+      status: userStateResponse.status,
+    });
     const repopulatedUserState = await getCachedUserStateForAccessToken({
       accessToken,
       app,

--- a/src/user-state/user-state-cache.ts
+++ b/src/user-state/user-state-cache.ts
@@ -1,0 +1,71 @@
+import type { Application } from 'express';
+import type UserStateConfiguration from '../interfaces/user-state-config.js';
+import RedisService, {
+  RedisCacheParseError,
+  RedisCacheReadError,
+  RedisClientUnavailableError,
+  type CachedJsonObject,
+  type RedisCacheError,
+} from '../services/redis-service.js';
+
+export const USER_STATE_CACHE_FAILURE_MESSAGE = 'Unable to retrieve user state from cache';
+
+export interface UserStateCacheLookupOptions {
+  accessToken: string;
+  app: Application;
+  redisService?: RedisService;
+  userStateConfiguration: UserStateConfiguration;
+}
+
+export type UserStateCacheLookupResult =
+  | { status: 'hit'; cacheKey: string; userState: CachedJsonObject }
+  | { status: 'miss'; cacheKey: string }
+  | { status: 'invalid-token' }
+  | { status: 'cache-error'; error: RedisCacheError };
+
+function isRedisCacheError(error: unknown): error is RedisCacheError {
+  return (
+    error instanceof RedisClientUnavailableError ||
+    error instanceof RedisCacheReadError ||
+    error instanceof RedisCacheParseError
+  );
+}
+
+function getMatchingUserState(cachedUserState: CachedJsonObject | null, cacheKey: string): CachedJsonObject | null {
+  if (!cachedUserState) {
+    return null;
+  }
+
+  return cachedUserState['cache_name'] === cacheKey ? cachedUserState : null;
+}
+
+export async function getCachedUserStateForAccessToken({
+  accessToken,
+  app,
+  redisService: configuredRedisService,
+  userStateConfiguration,
+}: UserStateCacheLookupOptions): Promise<UserStateCacheLookupResult> {
+  const redisService = configuredRedisService ?? new RedisService();
+  const cacheKey = redisService.getCacheKey(
+    accessToken,
+    userStateConfiguration.tokenClaim,
+    userStateConfiguration.cacheKeyPrefix,
+  );
+
+  if (!cacheKey) {
+    return { status: 'invalid-token' };
+  }
+
+  try {
+    const cachedUserState = await redisService.getCachedJsonObject(app, cacheKey);
+    const matchingUserState = getMatchingUserState(cachedUserState, cacheKey);
+
+    return matchingUserState ? { status: 'hit', cacheKey, userState: matchingUserState } : { status: 'miss', cacheKey };
+  } catch (error: unknown) {
+    if (!isRedisCacheError(error)) {
+      throw error;
+    }
+
+    return { status: 'cache-error', error };
+  }
+}


### PR DESCRIPTION
### Jira link
[PO-2876](https://tools.hmcts.net/jira/browse/PO-2876)

### Change description
Updated user-state handling to use the Redis-backed cache flow and clear cached user state during SSO logout.

## What Changed

- Added shared Redis cache lookup logic for user state using the configured token claim and cache key prefix.
- Updated SSO login user checks to use cached user state when available, avoiding unnecessary calls to `opal-user-service` when Redis already contains valid user state.
- Preserved the existing `opal-user-service` add/update behaviour on cache miss, including the `404` add-user and `409` update-user flows.
- Updated `/api/user-state` handling to read from Redis first, call `opal-user-service` on cache miss, then read the repopulated Redis entry.
- Added Redis cache deletion during SSO logout so the logged-in user’s cached state is removed before the session is destroyed.
- Added event logging around SSO login/logout, cache hit/miss/error paths, and user-state refresh decisions without logging tokens, cache keys, or user identifiers.
- Bumped package version to `0.0.32`.

## Notes

When SSO is enabled, login checks Redis first. If the cache is empty, `opal-user-service` is called and repopulates Redis. On logout, the Redis user-state entry is cleared so a later login starts from a clean cache state.

SSO-disabled behaviour is unchanged.

### Testing done
- `yarn build`
- `yarn lint`
- `yarn check:exports`
- `yarn check:exports:esm`
- `yarn check:pack-shape`
- Local validation in `opal-frontend`

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
