### PR TITLE
PO-7457 - Redirect SSO callback and user validation failures to branded error page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/opal-frontend-common-node",
   "type": "module",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "license": "MIT",
   "description": "Common nodejs library components for opal",
   "engines": {

--- a/src/interfaces/routes-config.ts
+++ b/src/interfaces/routes-config.ts
@@ -5,6 +5,7 @@ class RoutesConfiguration {
   clientSecret = '';
   tenantId = '';
   microsoftUrl = '';
+  internalServerErrorPath = '';
 
   constructor(initialValues?: Partial<RoutesConfiguration>) {
     Object.assign(this, initialValues);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -70,6 +70,7 @@ export class Routes {
         msalInstance: confidentialClient,
         ssoLoginCallback: ssoConfiguration.loginCallback,
         frontendHostname: routesConfiguration.frontendHostname,
+        internalServerErrorPath: routesConfiguration.internalServerErrorPath,
         clientId: routesConfiguration.clientId,
         opalUserServiceConfig,
         opalUserServiceUrl,

--- a/src/sso/sso-login-callback.ts
+++ b/src/sso/sso-login-callback.ts
@@ -6,6 +6,7 @@ import { Logger } from '@hmcts/nodejs-logging';
 import { handleCheckUser } from '../services/opal-user-service.js';
 import OpalUserServiceConfiguration from '../interfaces/opal-user-service-config.js';
 import type UserStateConfiguration from '../interfaces/user-state-config.js';
+import * as appInsights from 'applicationinsights';
 
 const logger = Logger.getLogger('sso-login-callback');
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -42,6 +43,12 @@ export default async function ssoLoginCallbackHandler({
   opalUserServiceUrl,
   userStateConfiguration,
 }: SsoLoginCallbackHandlerOptions): Promise<void> {
+  const operationId = appInsights.getCorrelationContext()?.operation?.id;
+
+  const internalServerErrorRedirectUrl = operationId
+    ? `${frontendHostname}/error/internal-server?operationId=${encodeURIComponent(operationId)}`
+    : `${frontendHostname}/error/internal-server`;
+
   // Build the token request for MSAL using the auth code returned by the IdP.
   const tokenRequest = {
     code: req.body['code'] as string,
@@ -53,7 +60,7 @@ export default async function ssoLoginCallbackHandler({
 
   if (!tokenRequest.code) {
     logger.warn('Missing authorization code on SSO callback');
-    res.status(400).send('Missing authorization code');
+    res.redirect(303, internalServerErrorRedirectUrl);
     return;
   }
 
@@ -86,7 +93,9 @@ export default async function ssoLoginCallbackHandler({
     if (!response?.accessToken) throw new Error('No access token in token response');
 
     const accessToken = response.accessToken;
+
     logger.info('SSO access token acquired, checking user management state');
+
     // Validate and manage user in opal-user-service
     const userManagementSuccess = await handleCheckUser(
       opalUserServiceUrl,
@@ -94,9 +103,10 @@ export default async function ssoLoginCallbackHandler({
       opalUserServiceConfig,
       userStateConfiguration ? { app: req.app, userStateConfiguration } : undefined,
     );
+
     if (!userManagementSuccess) {
       logger.error('User management failed after successful token acquisition');
-      res.status(500).send('User validation failed');
+      res.redirect(303, internalServerErrorRedirectUrl);
       return;
     }
 
@@ -108,6 +118,7 @@ export default async function ssoLoginCallbackHandler({
     };
 
     req.session.securityToken = securityToken;
+
     req.session.save(() => {
       logger.info('SSO login callback completed, redirecting to frontend');
       res.redirect(frontendHostname);
@@ -120,6 +131,7 @@ export default async function ssoLoginCallbackHandler({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       correlationId: (error as any)?.correlationId,
     });
-    res.status(500).send('SSO login callback failed');
+
+    res.redirect(303, internalServerErrorRedirectUrl);
   }
 }

--- a/src/sso/sso-login-callback.ts
+++ b/src/sso/sso-login-callback.ts
@@ -17,6 +17,7 @@ export interface SsoLoginCallbackHandlerOptions {
   msalInstance: ConfidentialClientApplication;
   ssoLoginCallback: string;
   frontendHostname: string;
+  internalServerErrorPath: string;
   clientId: string;
   opalUserServiceConfig: OpalUserServiceConfiguration;
   opalUserServiceUrl: string;
@@ -38,6 +39,7 @@ export default async function ssoLoginCallbackHandler({
   msalInstance,
   ssoLoginCallback,
   frontendHostname,
+  internalServerErrorPath,
   clientId,
   opalUserServiceConfig,
   opalUserServiceUrl,
@@ -45,9 +47,9 @@ export default async function ssoLoginCallbackHandler({
 }: SsoLoginCallbackHandlerOptions): Promise<void> {
   const operationId = appInsights.getCorrelationContext()?.operation?.id;
 
-  const internalServerErrorRedirectUrl = operationId
-    ? `${frontendHostname}/error/internal-server?operationId=${encodeURIComponent(operationId)}`
-    : `${frontendHostname}/error/internal-server`;
+  const internalServerErrorUrl = operationId
+    ? `${frontendHostname}${internalServerErrorPath}?operationId=${encodeURIComponent(operationId)}`
+    : `${frontendHostname}${internalServerErrorPath}`;
 
   // Build the token request for MSAL using the auth code returned by the IdP.
   const tokenRequest = {
@@ -60,7 +62,7 @@ export default async function ssoLoginCallbackHandler({
 
   if (!tokenRequest.code) {
     logger.warn('Missing authorization code on SSO callback');
-    res.redirect(303, internalServerErrorRedirectUrl);
+    res.redirect(303, internalServerErrorUrl);
     return;
   }
 
@@ -106,7 +108,7 @@ export default async function ssoLoginCallbackHandler({
 
     if (!userManagementSuccess) {
       logger.error('User management failed after successful token acquisition');
-      res.redirect(303, internalServerErrorRedirectUrl);
+      res.redirect(303, internalServerErrorUrl);
       return;
     }
 
@@ -132,6 +134,6 @@ export default async function ssoLoginCallbackHandler({
       correlationId: (error as any)?.correlationId,
     });
 
-    res.redirect(303, internalServerErrorRedirectUrl);
+    res.redirect(303, internalServerErrorUrl);
   }
 }


### PR DESCRIPTION
### Jira link
See [PO-7457](https://tools.hmcts.net/jira/browse/PO-7457)

The changes in this branch, also encapsulate the changes needed for: 
https://tools.hmcts.net/jira/browse/PO-7853
https://tools.hmcts.net/jira/browse/PO-7448

### Change description
- Replaced raw SSO callback error responses with redirects to the OPAL branded internal server error page.
- Added support for passing the Application Insights operationId to the error page when available.
- Updated missing authorisation code and user validation failure paths to follow the same branded error handling flow.
- Kept a safe fallback so the user is still redirected to the internal server page even when no operationId is available.

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
