### PR TITLE
P0-3938 add bounded retry and timeout handling for User Service

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/opal-frontend-common-node",
   "type": "module",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "license": "MIT",
   "description": "Common nodejs library components for opal",
   "engines": {

--- a/src/interfaces/opal-user-service-config.ts
+++ b/src/interfaces/opal-user-service-config.ts
@@ -2,6 +2,9 @@ class OpalUserServiceConfiguration {
   userStateUrl!: string;
   addUserUrl!: string;
   updateUserUrl!: string;
+  timeoutInMilliseconds!: number;
+  retryAttempts!: number;
+  retryDelayInMilliseconds!: number;
 }
 
 export default OpalUserServiceConfiguration;

--- a/src/services/opal-user-service-bounded-retry-options.interface.ts
+++ b/src/services/opal-user-service-bounded-retry-options.interface.ts
@@ -1,0 +1,10 @@
+import type { RetryDelay } from './opal-user-service-retry-delay.type.js';
+
+/**
+ * Options for running an async operation with a bounded retry policy.
+ */
+export interface BoundedRetryOptions {
+  maxAttempts: number;
+  delayMs: RetryDelay;
+  shouldRetry: (error: unknown, attempt: number) => boolean;
+}

--- a/src/services/opal-user-service-retry-delay.type.ts
+++ b/src/services/opal-user-service-retry-delay.type.ts
@@ -1,0 +1,7 @@
+/**
+ * Describes how long to wait before retrying an operation.
+ *
+ * The helper supports either a fixed delay or a per-attempt delay function so callers can keep simple policies
+ * simple while still allowing backoff when needed.
+ */
+export type RetryDelay = number | ((attempt: number) => number);

--- a/src/services/opal-user-service-retry.ts
+++ b/src/services/opal-user-service-retry.ts
@@ -1,19 +1,5 @@
-/**
- * Describes how long to wait before retrying an operation.
- *
- * The helper supports either a fixed delay or a per-attempt delay function so callers can keep simple policies
- * simple while still allowing backoff when needed.
- */
-export type RetryDelay = number | ((attempt: number) => number);
-
-/**
- * Options for running an async operation with a bounded retry policy.
- */
-export interface BoundedRetryOptions {
-  maxAttempts: number;
-  delayMs: RetryDelay;
-  shouldRetry: (error: unknown, attempt: number) => boolean;
-}
+import type { BoundedRetryOptions } from './opal-user-service-bounded-retry-options.interface.js';
+import type { RetryDelay } from './opal-user-service-retry-delay.type.js';
 
 function wait(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));

--- a/src/services/opal-user-service-retry.ts
+++ b/src/services/opal-user-service-retry.ts
@@ -1,0 +1,61 @@
+/**
+ * Describes how long to wait before retrying an operation.
+ *
+ * The helper supports either a fixed delay or a per-attempt delay function so callers can keep simple policies
+ * simple while still allowing backoff when needed.
+ */
+export type RetryDelay = number | ((attempt: number) => number);
+
+/**
+ * Options for running an async operation with a bounded retry policy.
+ */
+export interface BoundedRetryOptions {
+  maxAttempts: number;
+  delayMs: RetryDelay;
+  shouldRetry: (error: unknown, attempt: number) => boolean;
+}
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function getRetryDelay(delayMs: RetryDelay, attempt: number): number {
+  return typeof delayMs === 'function' ? delayMs(attempt) : delayMs;
+}
+
+/**
+ * Runs an async operation with a bounded retry policy.
+ *
+ * The first attempt happens immediately. Later attempts only run when `shouldRetry` returns true for the error
+ * raised by the previous attempt, and the helper stops once `maxAttempts` has been reached.
+ *
+ * @param operation - Async work to run.
+ * @param options - Retry limit, delay policy, and retryability check.
+ * @returns The successful result from `operation`.
+ * @throws The last error raised by `operation` when retries are exhausted or the error is not retryable.
+ */
+export async function withBoundedRetry<T>(operation: () => Promise<T>, options: BoundedRetryOptions): Promise<T> {
+  if (!Number.isInteger(options.maxAttempts) || options.maxAttempts < 1) {
+    throw new RangeError('maxAttempts must be an integer greater than 0');
+  }
+
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+    try {
+      return await operation();
+    } catch (error: unknown) {
+      const shouldRetry = options.shouldRetry(error, attempt);
+
+      if (!shouldRetry || attempt === options.maxAttempts) {
+        throw error;
+      }
+
+      const delay = getRetryDelay(options.delayMs, attempt);
+
+      if (delay > 0) {
+        await wait(delay);
+      }
+    }
+  }
+
+  throw new Error('Retry helper exited without returning or throwing');
+}

--- a/src/services/opal-user-service.ts
+++ b/src/services/opal-user-service.ts
@@ -1,10 +1,11 @@
-import axios from 'axios';
+import axios, { type AxiosResponse } from 'axios';
 import type { Application } from 'express';
 import { Logger } from '@hmcts/nodejs-logging';
 import OpalUserServiceConfiguration from '../interfaces/opal-user-service-config.js';
 import type UserStateConfiguration from '../interfaces/user-state-config.js';
 import { getCachedUserStateForAccessToken } from '../user-state/user-state-cache.js';
 import type RedisService from './redis-service.js';
+import { withBoundedRetry } from './opal-user-service-retry.js';
 
 const logger = Logger.getLogger('opal-user-service');
 
@@ -19,10 +20,36 @@ interface UserCheckResult {
   version?: string;
 }
 
+interface UserStateCheckResponseData {
+  user_id?: string;
+}
+
+interface UserConflictResponseData {
+  resourceId?: string;
+}
+
 export interface HandleCheckUserOptions {
   app: Application;
   redisService?: RedisService;
   userStateConfiguration: UserStateConfiguration;
+}
+
+const RETRYABLE_AXIOS_ERROR_CODES = new Set(['ECONNRESET', 'ETIMEDOUT', 'ECONNABORTED']);
+
+function isRetryableAxiosError(error: unknown): boolean {
+  if (!axios.isAxiosError(error)) {
+    return false;
+  }
+
+  if (error.response) {
+    return false;
+  }
+
+  return !!error.code && RETRYABLE_AXIOS_ERROR_CODES.has(error.code);
+}
+
+function getHeaderString(value: string | string[] | undefined): string | undefined {
+  return typeof value === 'string' ? value : undefined;
 }
 
 async function getCachedUserCheckResult(
@@ -69,7 +96,7 @@ async function getCachedUserCheckResult(
 async function checkUserExists(
   opalUserServiceTarget: string,
   accessToken: string,
-  userStateUrl: string,
+  config: OpalUserServiceConfiguration,
   options?: HandleCheckUserOptions,
 ): Promise<UserCheckResult> {
   const cachedUserResult = await getCachedUserCheckResult(accessToken, options);
@@ -80,30 +107,41 @@ async function checkUserExists(
 
   try {
     logger.info('Checking user state with opal-user-service');
-    const response = await axios.get(`${opalUserServiceTarget}${userStateUrl}`, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-        'X-New-Login': 'true',
+    const response = await withBoundedRetry<AxiosResponse<UserStateCheckResponseData>>(
+      () =>
+        axios.get<UserStateCheckResponseData>(`${opalUserServiceTarget}${config.userStateUrl}`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+            'X-New-Login': 'true',
+          },
+          timeout: config.timeoutInMilliseconds,
+        }),
+      {
+        maxAttempts: config.retryAttempts,
+        delayMs: config.retryDelayInMilliseconds,
+        shouldRetry: (error) => isRetryableAxiosError(error),
       },
-    });
+    );
 
     return {
       status: response.status,
       user_id: response.data?.user_id,
-      version: response.headers['etag'],
+      version: getHeaderString(response.headers['etag']),
     };
   } catch (error: unknown) {
-    if (axios.isAxiosError(error)) {
-      const status = error.response?.status;
-      if (status) {
+    if (axios.isAxiosError<UserConflictResponseData>(error)) {
+      const response = error.response;
+      const status = response?.status;
+
+      if (response && status) {
         logger.info('opal-user-service user state check returned non-success response', { status });
         return {
           status,
           // For 409 conflicts, extract user_id from resourceId
-          user_id: error.response?.data?.resourceId,
+          user_id: response.data?.resourceId,
           // Extract version from ETag header (same as success case)
-          version: error.response?.headers['etag'],
+          version: getHeaderString(response.headers['etag']),
         };
       }
 
@@ -125,16 +163,21 @@ async function checkUserExists(
  * @param accessToken - The access token for authentication
  * @returns Promise<boolean> - true if successful, false otherwise
  */
-async function addUser(opalUserServiceTarget: string, accessToken: string, addUserUrl: string): Promise<boolean> {
+async function addUser(
+  opalUserServiceTarget: string,
+  accessToken: string,
+  config: OpalUserServiceConfiguration,
+): Promise<boolean> {
   try {
     const response = await axios.post(
-      `${opalUserServiceTarget}${addUserUrl}`,
+      `${opalUserServiceTarget}${config.addUserUrl}`,
       {},
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,
           'Content-Type': 'application/json',
         },
+        timeout: config.timeoutInMilliseconds,
       },
     );
 
@@ -148,17 +191,26 @@ async function addUser(opalUserServiceTarget: string, accessToken: string, addUs
 export async function getUserStateFromUserService(
   opalUserServiceTarget: string,
   accessToken: string,
-  userStateUrl: string,
+  config: OpalUserServiceConfiguration,
 ): Promise<UserStateLookupResult> {
   try {
-    const response = await axios.get<unknown>(`${opalUserServiceTarget}${userStateUrl}`, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        Accept: 'application/json',
-        'X-New-Login': 'false',
+    const response = await withBoundedRetry<AxiosResponse<unknown>>(
+      () =>
+        axios.get<unknown>(`${opalUserServiceTarget}${config.userStateUrl}`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            Accept: 'application/json',
+            'X-New-Login': 'false',
+          },
+          timeout: config.timeoutInMilliseconds,
+          validateStatus: () => true,
+        }),
+      {
+        maxAttempts: config.retryAttempts,
+        delayMs: config.retryDelayInMilliseconds,
+        shouldRetry: (error) => isRetryableAxiosError(error),
       },
-      validateStatus: () => true,
-    });
+    );
 
     return {
       data: response.data,
@@ -193,7 +245,7 @@ export async function getUserStateFromUserService(
 async function updateUser(
   opalUserServiceTarget: string,
   accessToken: string,
-  updateUserUrl: string,
+  config: OpalUserServiceConfiguration,
   userId: string,
   version: string,
 ): Promise<boolean> {
@@ -204,7 +256,14 @@ async function updateUser(
       'If-Match': version,
     };
 
-    const response = await axios.put(`${opalUserServiceTarget}${updateUserUrl}/${userId}`, {}, { headers });
+    const response = await axios.put(
+      `${opalUserServiceTarget}${config.updateUserUrl}/${userId}`,
+      {},
+      {
+        headers,
+        timeout: config.timeoutInMilliseconds,
+      },
+    );
 
     return response.status === 200;
   } catch (error) {
@@ -236,7 +295,7 @@ export async function handleCheckUser(
   config: OpalUserServiceConfiguration,
   options?: HandleCheckUserOptions,
 ): Promise<boolean> {
-  const userResult = await checkUserExists(opalUserServiceTarget, accessToken, config.userStateUrl, options);
+  const userResult = await checkUserExists(opalUserServiceTarget, accessToken, config, options);
 
   switch (userResult.status) {
     case 200:
@@ -245,7 +304,7 @@ export async function handleCheckUser(
 
     case 404: {
       logger.info('User not found, attempting to add user');
-      const addResult = await addUser(opalUserServiceTarget, accessToken, config.addUserUrl);
+      const addResult = await addUser(opalUserServiceTarget, accessToken, config);
       if (addResult) {
         logger.info('User successfully added');
         return true;
@@ -270,7 +329,7 @@ export async function handleCheckUser(
       const updateResult = await updateUser(
         opalUserServiceTarget,
         accessToken,
-        config.updateUserUrl,
+        config,
         userResult.user_id,
         userResult.version,
       );

--- a/src/services/opal-user-service.ts
+++ b/src/services/opal-user-service.ts
@@ -52,6 +52,23 @@ function getHeaderString(value: string | string[] | undefined): string | undefin
   return typeof value === 'string' ? value : undefined;
 }
 
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function getSafeAxiosLogDetails(error: unknown): Record<string, number | string | undefined> {
+  if (!axios.isAxiosError(error)) {
+    return { message: getErrorMessage(error) };
+  }
+
+  return {
+    message: error.message,
+    code: error.code,
+    status: error.response?.status,
+    statusText: error.response?.statusText,
+  };
+}
+
 async function getCachedUserCheckResult(
   accessToken: string,
   options?: HandleCheckUserOptions,
@@ -145,14 +162,11 @@ async function checkUserExists(
         };
       }
 
-      logger.error('Axios error without response status when checking user state', {
-        message: error.message,
-        code: error.code,
-      });
+      logger.error('Axios error without response status when checking user state', getSafeAxiosLogDetails(error));
       return { status: 500 };
     }
 
-    logger.error('Unexpected error when checking user state', error);
+    logger.error('Unexpected error when checking user state', getSafeAxiosLogDetails(error));
     return { status: 500 };
   }
 }
@@ -182,8 +196,8 @@ async function addUser(
     );
 
     return response.status === 201 || response.status === 200;
-  } catch (error) {
-    logger.error('Error adding user', error);
+  } catch (error: unknown) {
+    logger.error('Error adding user', getSafeAxiosLogDetails(error));
     return false;
   }
 }
@@ -218,12 +232,9 @@ export async function getUserStateFromUserService(
     };
   } catch (error: unknown) {
     if (axios.isAxiosError(error)) {
-      logger.error('Axios error without response when retrieving user state', {
-        message: error.message,
-        code: error.code,
-      });
+      logger.error('Axios error without response when retrieving user state', getSafeAxiosLogDetails(error));
     } else {
-      logger.error('Unexpected error when retrieving user state', error);
+      logger.error('Unexpected error when retrieving user state', getSafeAxiosLogDetails(error));
     }
 
     return {
@@ -266,19 +277,8 @@ async function updateUser(
     );
 
     return response.status === 200;
-  } catch (error) {
-    if (axios.isAxiosError(error)) {
-      logger.error('updateUser axios error', {
-        status: error.response?.status,
-        statusText: error.response?.statusText,
-        data: error.response?.data,
-        url: error.config?.url,
-        method: error.config?.method,
-        message: error.message,
-      });
-    } else {
-      logger.error('updateUser non-axios error', { error: String(error) });
-    }
+  } catch (error: unknown) {
+    logger.error('Error updating user', getSafeAxiosLogDetails(error));
     return false;
   }
 }

--- a/src/services/opal-user-service.ts
+++ b/src/services/opal-user-service.ts
@@ -69,6 +69,17 @@ function getSafeAxiosLogDetails(error: unknown): Record<string, number | string 
   };
 }
 
+function getSafeRetryLogDetails(
+  error: unknown,
+  config: OpalUserServiceConfiguration,
+): Record<string, number | string | undefined> {
+  return {
+    retryAttempts: config.retryAttempts,
+    retryDelayInMilliseconds: config.retryDelayInMilliseconds,
+    ...getSafeAxiosLogDetails(error),
+  };
+}
+
 async function getCachedUserCheckResult(
   accessToken: string,
   options?: HandleCheckUserOptions,
@@ -162,7 +173,10 @@ async function checkUserExists(
         };
       }
 
-      logger.error('Axios error without response status when checking user state', getSafeAxiosLogDetails(error));
+      logger.error(
+        'Retry exhausted when checking user state with opal-user-service',
+        getSafeRetryLogDetails(error, config),
+      );
       return { status: 500 };
     }
 
@@ -232,7 +246,10 @@ export async function getUserStateFromUserService(
     };
   } catch (error: unknown) {
     if (axios.isAxiosError(error)) {
-      logger.error('Axios error without response when retrieving user state', getSafeAxiosLogDetails(error));
+      logger.error(
+        'Retry exhausted when retrieving user state from opal-user-service',
+        getSafeRetryLogDetails(error, config),
+      );
     } else {
       logger.error('Unexpected error when retrieving user state', getSafeAxiosLogDetails(error));
     }

--- a/src/user-state/index.ts
+++ b/src/user-state/index.ts
@@ -96,11 +96,7 @@ export async function getUserState({
       break;
   }
 
-  const userStateResponse = await getUserStateFromUserService(
-    opalUserServiceUrl,
-    accessToken,
-    opalUserServiceConfig.userStateUrl,
-  );
+  const userStateResponse = await getUserStateFromUserService(opalUserServiceUrl, accessToken, opalUserServiceConfig);
 
   if (isSuccessfulResponse(userStateResponse.status)) {
     logger.info('opal-user-service returned successful response for user state, reading repopulated cache', {


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PO-3938](https://tools.hmcts.net/jira/browse/PO-3938)

### Change description

Tech debt story to add explicit timeout/retry (addUser and updateUser should not be retried by default). Add explicit Axios timeout handling for User Service calls.

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

The retry loop added for PO-3938 runs in `opal-frontend-common-node-lib` on the Node server side. It is not browser-side Angular code.

Chrome DevTools can be used to block the browser-visible `/api/user-state` request and confirm that the frontend handles a failed user-state response without crashing. However, Chrome DevTools cannot prove the internal Axios retry behaviour, because the retryable request is made from the frontend Node server to User Service, not from the browser.

The frontend unit test covers the part that `opal-frontend` owns: config values for timeout, retry attempts, and retry delay are read from frontend config and passed into `OpalUserServiceConfiguration`.

The following behaviours are implemented in `opal-frontend-common-node-lib` and should be covered by code review and/or QA-owned integration testing:
- user-state retrieval retries transient no-response/network/timeout Axios errors
- retry exhaustion returns the consistent fallback response
- `addUser` and `updateUser` are not retried
- update still sends the existing `If-Match` header

The common-node logging deliberately avoids tokens, payloads, request config, URLs, and PII. It logs safe Axios diagnostics such as message, code, status, and status text.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
