### PR TITLE
Fix for proxy: classify EPIPE as retryable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog and this project follows semantic versio
 
 ### Changed
 - _Add entries here for each PR that changes public behavior, exports, or consumer configuration._
+- Treat `EPIPE` broken-pipe proxy failures as retryable gateway timeouts.
 - Add a configurable `user-state` route module for returning cached user state from the logged-in session.
 - BREAKING: `Routes.enableFor` consumers must provide `userStateConfiguration` when enabling common routes.
 - Add a reusable `redis` service for reading JSON object cache entries from the shared session Redis client at

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/opal-frontend-common-node",
   "type": "module",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "license": "MIT",
   "description": "Common nodejs library components for opal",
   "engines": {

--- a/src/proxy/opal-api-proxy/index.ts
+++ b/src/proxy/opal-api-proxy/index.ts
@@ -15,7 +15,7 @@ type ProxyErrorResponse = {
   retriable: boolean;
 };
 
-const RETRYABLE_PROXY_ERROR_CODES = new Set(['ECONNRESET', 'ENOTFOUND', 'ECONNREFUSED', 'ETIMEDOUT']);
+const RETRYABLE_PROXY_ERROR_CODES = new Set(['ECONNRESET', 'ENOTFOUND', 'ECONNREFUSED', 'EPIPE', 'ETIMEDOUT']);
 
 /**
  * Narrows the proxy error response target to an HTTP response before writing to it.


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PO-3939](https://tools.hmcts.net/jira/browse/PO-3939)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

## Summary

Follow-up fix for [PO-3939](https://tools.hmcts.net/jira/browse/PO-3939): UI - Tech Debt - Add explicit timeout and error mapping for common frontend API proxy.

Adds `EPIPE` (broken pipe) to the proxy transport-error allow-list. When the upstream closes its socket during a write, `OpalApiProxy` now returns the same deterministic retryable response as other timeout/network failures:

- HTTP `504 Gateway Timeout`
- `retriable: true`

The proxy still does not replay requests. The consuming frontend remains responsible for deciding whether an opted-in request is safe to retry.

## Release

- Bumped `@hmcts/opal-frontend-common-node` from `0.0.43` to `0.0.44`.
- Added an `Unreleased` changelog entry.

## Validation

- `corepack yarn install --immutable`
- `corepack yarn build`
- `corepack yarn lint`
- `corepack yarn check:exports`
- `corepack yarn check:pack-shape`
- `corepack yarn check:exports:esm`
- `npm pack --dry-run`
- `git diff --check`

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

Local Testing Completed

1. Built a local common-node package from the PO-3939 branch and installed it into opal-frontend.
2. Started opal-frontend locally with the PO-3939 tarball.
3. Confirmed http://localhost:4200/sign-in returns 200 OK.
4. Browser smoke test: stopped the local Fines Service container and repeated a safe GET request. The frontend received an immediate 504, confirming the proxy maps a connection/network failure deterministically.
5. The immediate response is expected for a refused connection. The proxy can fail immediately when the upstream is unavailable; it does not need to wait 30 seconds in that case.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
